### PR TITLE
[TASK] Maintain `composer.json` and `ext_emconf.php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
 	"description": "Extension for showing academic partners in list and map view",
 	"minimum-stability": "stable",
 	"license": "GPL-2.0-or-later",
-	"version": "1.0.0",
 	"author": [
 		{
 			"name": "Jan-Philipp Halle",
@@ -22,6 +21,9 @@
 		}
 	},
 	"extra": {
+		"branch-alias": {
+			"dev-main": "1.x.x-dev"
+		},
 		"typo3/cms": {
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",
 			"extension-key": "academic_partners",
@@ -32,12 +34,12 @@
 	},
 	"require": {
 		"php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3",
-		"fgtclb/category-types": "*",
-		"fgtclb/page-backend-layout": "*",
-		"typo3/cms-backend": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-core": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-extbase": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-fluid": "^11.5 || ^12.4 || ^13.4"
+		"fgtclb/category-types": "^1.0 || 1.*.*@dev",
+		"fgtclb/page-backend-layout": "^1.0 || 1.*.*@dev",
+		"typo3/cms-backend": "^11.5 || ^12.4",
+		"typo3/cms-core": "^11.5 || ^12.4",
+		"typo3/cms-extbase": "^11.5 || ^12.4",
+		"typo3/cms-fluid": "^11.5 || ^12.4"
 	},
 	"require-dev": {
 		"fakerphp/faker": "^1.23",
@@ -47,12 +49,12 @@
 		"phpstan/phpstan": "^1.10",
 		"phpunit/phpunit": "^10.1",
 		"saschaegerer/phpstan-typo3": "^1.8",
-		"typo3/cms-extensionmanager": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-fluid-styled-content": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-frontend": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-info": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-lowlevel": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-tstemplate": "^11.5 || ^12.4 || ^13.4",
+		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
+		"typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
+		"typo3/cms-frontend": "^11.5 || ^12.4",
+		"typo3/cms-info": "^11.5 || ^12.4",
+		"typo3/cms-lowlevel": "^11.5 || ^12.4",
+		"typo3/cms-tstemplate": "^11.5 || ^12.4",
 		"typo3/coding-standards": "^0.7.1",
 		"typo3/testing-framework": "^7.0"
 	},

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -5,12 +5,15 @@ $EM_CONF[$_EXTKEY] = [
     'description' => 'Extension for showing academic partners in list and map view',
     'category' => 'fe,be',
     'state' => 'beta',
-    'version' => '1.0.0',
+    'version' => '1.0.4',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-13.4.99',
-            'page_backend_layout' => '*',
-            'category_types' => '*',
+            'typo3' => '11.5.0-12.4.99',
+            'backend' => '11.5.0-12.4.99',
+            'extbase' => '11.5.0-12.4.99',
+            'fluid' => '11.5.0-12.4.99',
+            'page_backend_layout' => '1.0.0-1.9.99',
+            'category_types' => '1.0.0-1.9.99',
         ],
     ],
     'autoload' => [


### PR DESCRIPTION
Main branch of this extension is target towards
TYPO3 v11 and v12 only, following the two-core
version per extension version policy.

Align the composer.json to match this policy.

Further, invalid `version` key is removed from
`composer.json` and the `ext_emconf.php` config
is syncronized.

Version in `ext_emconf.php` as mandantory setting
is set to the next patchlevel version `1.0.4`.

Used command(s):

```shell
composer2-81 require --no-update \
    "php":"^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3" \
    "fgtclb/category-types":"^1.0 || 1.*.*@dev" \
    "fgtclb/page-backend-layout":"^1.0 || 1.*.*@dev" \
    "typo3/cms-backend":"^11.5 || ^12.4" \
    "typo3/cms-core":"^11.5 || ^12.4" \
    "typo3/cms-extbase":"^11.5 || ^12.4" \
    "typo3/cms-fluid":"^11.5 || ^12.4"

composer2-81 require --dev --no-update \
    "typo3/cms-extensionmanager":"^11.5 || ^12.4" \
    "typo3/cms-fluid-styled-content":"^11.5 || ^12.4" \
    "typo3/cms-frontend":"^11.5 || ^12.4" \
    "typo3/cms-info":"^11.5 || ^12.4" \
    "typo3/cms-lowlevel":"^11.5 || ^12.4" \
    "typo3/cms-tstemplate":"^11.5 || ^12.4"
```
