### PR TITLE
[BUGFIX] Use correct branch alias version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"extra": {
 		"branch-alias": {
 			"dev-main": "1.x.x-dev",
-			"dev-compatibility": "2.x.x.dev"
+			"dev-compatibility": "2.x.x-dev"
 		},
 		"typo3/cms": {
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",


### PR DESCRIPTION
Used command(s):

```shell
composer config \
  extra.branch-alias.dev-compatibility "2.x.x-dev"
```
