### PR TITLE
[TASK] Maintain `composer.json` and `ext_emconf.php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,72 +1,77 @@
 {
-	"name": "fgtclb/academic-partners",
-	"type": "typo3-cms-extension",
-	"description": "Extension for showing academic partners in list and map view",
-	"minimum-stability": "stable",
-	"license": "GPL-2.0-or-later",
-	"author": [
-		{
-			"name": "Jan-Philipp Halle",
-			"email": "p.halle@web-vision.de"
-		}
-	],
-	"config": {
-		"vendor-dir": ".Build/vendor",
-		"bin-dir": ".Build/bin",
-		"optimize-autoloader": true,
-		"sort-packages": true,
-		"allow-plugins": {
-			"typo3/class-alias-loader": true,
-			"typo3/cms-composer-installers": true
-		}
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-main": "1.x.x-dev",
-			"dev-compatibility": "2.x.x-dev"
-		},
-		"typo3/cms": {
-			"cms-package-dir": "{$vendor-dir}/typo3/cms",
-			"extension-key": "academic_partners",
-			"ignore-as-root": false,
-			"web-dir": ".Build/public",
-			"app-dir": ".Build"
-		}
-	},
-	"require": {
-		"php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3",
-		"fgtclb/category-types": "^1.0 || 1.*.*@dev",
-		"fgtclb/page-backend-layout": "^1.0 || 1.*.*@dev",
-		"typo3/cms-backend": "^11.5 || ^12.4",
-		"typo3/cms-core": "^11.5 || ^12.4",
-		"typo3/cms-extbase": "^11.5 || ^12.4",
-		"typo3/cms-fluid": "^11.5 || ^12.4"
-	},
-	"require-dev": {
-		"fakerphp/faker": "^1.23",
-		"friendsofphp/php-cs-fixer": "^3.14",
-		"helhum/typo3-console": "^7.1.6 || ^8.0.2",
-		"helmich/typo3-typoscript-lint": "^3.1.0",
-		"phpstan/phpstan": "^1.10",
-		"phpunit/phpunit": "^10.1",
-		"saschaegerer/phpstan-typo3": "^1.8",
-		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
-		"typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
-		"typo3/cms-frontend": "^11.5 || ^12.4",
-		"typo3/cms-info": "^11.5 || ^12.4",
-		"typo3/cms-lowlevel": "^11.5 || ^12.4",
-		"typo3/cms-tstemplate": "^11.5 || ^12.4",
-		"typo3/coding-standards": "^0.7.1",
-		"typo3/testing-framework": "^7.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"FGTCLB\\AcademicPartners\\": "Classes/"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"FGTCLB\\AcademicPartners\\Tests\\": "Tests/"
-		}
-	}
+    "name": "fgtclb/academic-partners",
+    "type": "typo3-cms-extension",
+    "description": "Extension for showing academic partners in list and map view",
+    "minimum-stability": "stable",
+    "license": "GPL-2.0-or-later",
+    "author": [
+        {
+            "name": "Jan-Philipp Halle",
+            "email": "p.halle@web-vision.de"
+        }
+    ],
+    "config": {
+        "vendor-dir": ".Build/vendor",
+        "bin-dir": ".Build/bin",
+        "optimize-autoloader": true,
+        "sort-packages": true,
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.x.x-dev",
+            "dev-compatibility": "2.x.x-dev"
+        },
+        "typo3/cms": {
+            "cms-package-dir": "{$vendor-dir}/typo3/cms",
+            "extension-key": "academic_partners",
+            "ignore-as-root": false,
+            "web-dir": ".Build/public",
+            "app-dir": ".Build"
+        }
+    },
+    "require": {
+        "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3",
+        "fgtclb/category-types": "^1.0 || 1.*.*@dev",
+        "typo3/cms-backend": "^11.5 || ^12.4",
+        "typo3/cms-core": "^11.5 || ^12.4",
+        "typo3/cms-extbase": "^11.5 || ^12.4",
+        "typo3/cms-fluid": "^11.5 || ^12.4"
+    },
+    "require-dev": {
+        "fakerphp/faker": "^1.23",
+        "friendsofphp/php-cs-fixer": "^3.14",
+        "helhum/typo3-console": "^7.1.6 || ^8.0.2",
+        "helmich/typo3-typoscript-lint": "^3.1.0",
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^10.1",
+        "saschaegerer/phpstan-typo3": "^1.8",
+        "typo3/cms-extensionmanager": "^11.5 || ^12.4",
+        "typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
+        "typo3/cms-frontend": "^11.5 || ^12.4",
+        "typo3/cms-info": "^11.5 || ^12.4",
+        "typo3/cms-lowlevel": "^11.5 || ^12.4",
+        "typo3/cms-tstemplate": "^11.5 || ^12.4",
+        "typo3/coding-standards": "^0.7.1",
+        "typo3/testing-framework": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "FGTCLB\\AcademicPartners\\": "Classes/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "FGTCLB\\AcademicPartners\\Tests\\": "Tests/"
+        }
+    },
+    "conflict": {
+        "fgtclb/category-types": "<1.0.0 || >=2.0.0"
+    },
+    "suggest": {
+        "fgtclb/page-backend-layout": "Provides backend category preview"
+    }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,8 +12,10 @@ $EM_CONF[$_EXTKEY] = [
             'backend' => '11.5.0-12.4.99',
             'extbase' => '11.5.0-12.4.99',
             'fluid' => '11.5.0-12.4.99',
-            'page_backend_layout' => '1.0.0-1.9.99',
             'category_types' => '1.0.0-1.9.99',
+        ],
+        'suggest' => [
+            'page_backend_layout' => '1.0.0-1.9.99',
         ],
     ],
     'autoload' => [


### PR DESCRIPTION
* Remove `fgtclb/page-backend-layout` as hard dependency
  from `composer.json` and `ext_emconf.php`.
* Add suggest for `fgtclb/page-backend-layout` to the
  `composer.json` and `ext_emconf.php`.
* Add conflict for invalid `fgtclb/category-types` version
  to `composer.json`.

Used command(s):

```shell
composer remove --no-update \
  'fgtclb/page-backend-layout' \
&& mv composer.json composer.json.orig \
&& cat <<< $(jq --indent 4 '."conflict" += {"fgtclb/category-types": "<1.0.0 || >=2.0.0"}' composer.json.orig) > composer.json \
&& rm -rf composer.json.orig \
&& mv composer.json composer.json.orig \
&& cat <<< $(jq --indent 4 '."suggest" += {"fgtclb/page-backend-layout": "Provides backend category preview"}' composer.json.orig) > composer.json \
&& rm -rf composer.json.orig
```
